### PR TITLE
pkgs: bump 2026-06-23

### DIFF
--- a/pkgs/nix-eval-jobs/default.nix
+++ b/pkgs/nix-eval-jobs/default.nix
@@ -1,13 +1,13 @@
 { pkgsPrev, fetchFromGitHub }:
 
 pkgsPrev.nix-eval-jobs.overrideAttrs (final: prev: {
-  version = "2.34.2";
+  version = "2.34.3";
 
   src = fetchFromGitHub {
     owner = "nixos";
     repo = "nix-eval-jobs";
     tag = "v${final.version}";
-    hash = "sha256-BtL2NmpXyrVRc3ffxLiIj193T5dCX+0A8Fot+uMM6uI=";
+    hash = "sha256-YaVQAgBxWbUBFHXLBLzdUyVvuA/DDw80SEnn9iq0Veo=";
   };
 
   passthru = (prev.passthru or { }) // { autobump = true; };


### PR DESCRIPTION
- pkgs/nix-eval-jobs: 2.34.2 -> 2.34.3