### PR TITLE
pkgs: bump 2026-07-28

### DIFF
--- a/pkgs/tailscale/default.nix
+++ b/pkgs/tailscale/default.nix
@@ -10,13 +10,13 @@
 }:
 
 pkgsPrev.tailscale.overrideAttrs (prev: {
-  version = "1.103.9";
+  version = "1.103.19";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "cd34d441be2f277221e81672125f73ec3e8cb16d";
-    hash = "sha256-KWDuY7P/hoHs7J0n/toh2Kx0vmnEPupmyqvUDWnUZPQ=";
+    rev = "d0b4d44963d5ea6ce2f8bd312de749dd2e5afa7d";
+    hash = "sha256-JUo+olySO9EvCfHH2kMeY++l/Qc3wsDfGolhmz/V/B0=";
   };
 
   vendorHash = "sha256-5ClQ5fSyEHUlhPtZI0ir8ddQRXSnqOG5VIJ3KjWtXmw=";

--- a/pkgs/verus/default.nix
+++ b/pkgs/verus/default.nix
@@ -12,13 +12,13 @@
 
 let
   pname = "verus";
-  version = "release/rolling/0.2026.07.26.372b6bc";
+  version = "release/rolling/0.2026.07.27.31579f0";
   src = fetchFromGitHub {
     leaveDotGit = true;
     owner = "verus-lang";
     repo = "verus";
     tag = version;
-    hash = "sha256-cQVenuGStD51q2+qrIXDP4Lgui5WiAfthDf9cvIeu+Q=";
+    hash = "sha256-BDwNML//Zwz1hcFKB2d4eJaebxWWMCT6gdIQAFmfURw=";
   };
 
   rustToolchain = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";


### PR DESCRIPTION
- pkgs/tailscale: 1.103.9 -> 1.103.19
- pkgs/verus: release/rolling/0.2026.07.26.372b6bc -> release/rolling/0.2026.07.27.31579f0