### PR TITLE
pkgs: bump 2026-07-29

### DIFF
--- a/pkgs/tailscale/default.nix
+++ b/pkgs/tailscale/default.nix
@@ -10,13 +10,13 @@
 }:
 
 pkgsPrev.tailscale.overrideAttrs (prev: {
-  version = "1.103.19";
+  version = "1.103.25";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "d0b4d44963d5ea6ce2f8bd312de749dd2e5afa7d";
-    hash = "sha256-JUo+olySO9EvCfHH2kMeY++l/Qc3wsDfGolhmz/V/B0=";
+    rev = "5a41b799559cbff2aeeefd380f2e7c4b399e8be2";
+    hash = "sha256-BhW6DKz2T+RrDiONoaqiUnd2Dq5xOF2T1RbTxBpIplM=";
   };
 
   vendorHash = "sha256-5ClQ5fSyEHUlhPtZI0ir8ddQRXSnqOG5VIJ3KjWtXmw=";

--- a/pkgs/verus/default.nix
+++ b/pkgs/verus/default.nix
@@ -12,13 +12,13 @@
 
 let
   pname = "verus";
-  version = "release/rolling/0.2026.07.27.31579f0";
+  version = "release/rolling/0.2026.07.28.53af027";
   src = fetchFromGitHub {
     leaveDotGit = true;
     owner = "verus-lang";
     repo = "verus";
     tag = version;
-    hash = "sha256-BDwNML//Zwz1hcFKB2d4eJaebxWWMCT6gdIQAFmfURw=";
+    hash = "sha256-0mfLIOuFvI4182N58pk83gppf20E8izrnEKYG7IB0TI=";
   };
 
   rustToolchain = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";


### PR DESCRIPTION
- pkgs/tailscale: 1.103.19 -> 1.103.25
- pkgs/verus: release/rolling/0.2026.07.27.31579f0 -> release/rolling/0.2026.07.28.53af027