### PR TITLE
pkgs: bump 2026-08-02

### DIFF
--- a/pkgs/tailscale/default.nix
+++ b/pkgs/tailscale/default.nix
@@ -10,13 +10,13 @@
 }:
 
 pkgsPrev.tailscale.overrideAttrs (prev: {
-  version = "1.103.65";
+  version = "1.103.66";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "d645114dd4c96543c08abe410ef774f8368738d7";
-    hash = "sha256-0uP3nsq0GQTHJSdwaH+DERWG69/tQtywylcVTVivyaY=";
+    rev = "4c4d1c35f83a21c6069ae09de69b246ed1993f3e";
+    hash = "sha256-qxPZA68bAGB9ZSxTE3EcmoUtEECNqUCaGEO2aJrm+ws=";
   };
 
   vendorHash = "sha256-kvfs58mc2bwjDSTeEAdKh+bCPc3aP/5/6qG5YEHgS18=";

--- a/pkgs/verus/default.nix
+++ b/pkgs/verus/default.nix
@@ -12,13 +12,13 @@
 
 let
   pname = "verus";
-  version = "release/rolling/0.2026.07.31.9454114";
+  version = "release/rolling/0.2026.08.01.f598233";
   src = fetchFromGitHub {
     leaveDotGit = true;
     owner = "verus-lang";
     repo = "verus";
     tag = version;
-    hash = "sha256-xz3VRv9F19cDDQRmboVhpombVrG2vLvU6Ah1fmNaYKA=";
+    hash = "sha256-+ATospF4xXvSi4MCMy5RSTIm5NhQlXg02Tdm7RD0Zs4=";
   };
 
   rustToolchain = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";


### PR DESCRIPTION
- pkgs/tailscale: 1.103.65 -> 1.103.66
- pkgs/verus: release/rolling/0.2026.07.31.9454114 -> release/rolling/0.2026.08.01.f598233