### PR TITLE
pkgs: bump 2026-08-05

### DIFF
--- a/pkgs/tailscale/default.nix
+++ b/pkgs/tailscale/default.nix
@@ -10,13 +10,13 @@
 }:
 
 pkgsPrev.tailscale.overrideAttrs (prev: {
-  version = "1.103.66";
+  version = "1.103.74";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "4c4d1c35f83a21c6069ae09de69b246ed1993f3e";
-    hash = "sha256-qxPZA68bAGB9ZSxTE3EcmoUtEECNqUCaGEO2aJrm+ws=";
+    rev = "616dcd53784e80711284e6223a8975fa16fe5d8b";
+    hash = "sha256-Zts/rPj+kEop+x8uSdfPqJcGbbmBLFqr9bBEMEkneCQ=";
   };
 
   vendorHash = "sha256-kvfs58mc2bwjDSTeEAdKh+bCPc3aP/5/6qG5YEHgS18=";

--- a/pkgs/verus/default.nix
+++ b/pkgs/verus/default.nix
@@ -12,13 +12,13 @@
 
 let
   pname = "verus";
-  version = "release/rolling/0.2026.08.04.6a3e758";
+  version = "release/rolling/0.2026.08.05.9140635";
   src = fetchFromGitHub {
     leaveDotGit = true;
     owner = "verus-lang";
     repo = "verus";
     tag = version;
-    hash = "sha256-Zfsab+D3A6KxjQvxlpRc236Zzc6mHpjsX9fzZy35fjY=";
+    hash = "sha256-In2ZmZntjPT9/TOOAJEVrOHke22UMsGtQETgYEGXfQ4=";
   };
 
   rustToolchain = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";


### PR DESCRIPTION
- pkgs/tailscale: 1.103.66 -> 1.103.74
- pkgs/verus: release/rolling/0.2026.08.04.6a3e758 -> release/rolling/0.2026.08.05.9140635