### PR TITLE
pkgs: bump 2026-08-07

### DIFF
--- a/pkgs/tailscale/default.nix
+++ b/pkgs/tailscale/default.nix
@@ -10,13 +10,13 @@
 }:
 
 pkgsPrev.tailscale.overrideAttrs (prev: {
-  version = "1.103.77";
+  version = "1.103.80";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "deded79f0e6c5d97ac7efd2b10291f58c800caf6";
-    hash = "sha256-OopFSJN4HC1mUOYecUhWg0miKC28fuUjRlAiy6Kyuqc=";
+    rev = "a265908a72ddab93de230a1b1495e252eefa9aee";
+    hash = "sha256-HgV5z4N8aqhzZPt2+meI+oVmoYbDgmRF+99B3Qj2uJE=";
   };
 
   vendorHash = "sha256-kvfs58mc2bwjDSTeEAdKh+bCPc3aP/5/6qG5YEHgS18=";

--- a/pkgs/verus/default.nix
+++ b/pkgs/verus/default.nix
@@ -12,13 +12,13 @@
 
 let
   pname = "verus";
-  version = "release/rolling/0.2026.08.05.9140635";
+  version = "release/rolling/0.2026.08.07.b678730";
   src = fetchFromGitHub {
     leaveDotGit = true;
     owner = "verus-lang";
     repo = "verus";
     tag = version;
-    hash = "sha256-In2ZmZntjPT9/TOOAJEVrOHke22UMsGtQETgYEGXfQ4=";
+    hash = "sha256-Eggdfc/e/BGQuYt2gh4ghkvYWGPXjQslovoN/YQ4WHg=";
   };
 
   rustToolchain = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";


### PR DESCRIPTION
- pkgs/tailscale: 1.103.77 -> 1.103.80
- pkgs/verus: release/rolling/0.2026.08.05.9140635 -> release/rolling/0.2026.08.07.b678730