### PR TITLE
pkgs: bump 2026-08-08

### DIFF
--- a/pkgs/tailscale/default.nix
+++ b/pkgs/tailscale/default.nix
@@ -10,13 +10,13 @@
 }:
 
 pkgsPrev.tailscale.overrideAttrs (prev: {
-  version = "1.103.80";
+  version = "1.103.84";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "a265908a72ddab93de230a1b1495e252eefa9aee";
-    hash = "sha256-HgV5z4N8aqhzZPt2+meI+oVmoYbDgmRF+99B3Qj2uJE=";
+    rev = "00699abdfbbe0972daa71290203878d828bf4037";
+    hash = "sha256-YKncEZgf87JtzWSEbs21sD/y5EoTiKo2mUSJ8GGX01c=";
   };
 
   vendorHash = "sha256-kvfs58mc2bwjDSTeEAdKh+bCPc3aP/5/6qG5YEHgS18=";

--- a/pkgs/verus/default.nix
+++ b/pkgs/verus/default.nix
@@ -12,13 +12,13 @@
 
 let
   pname = "verus";
-  version = "release/rolling/0.2026.08.07.b678730";
+  version = "release/rolling/0.2026.08.07.5456f8c";
   src = fetchFromGitHub {
     leaveDotGit = true;
     owner = "verus-lang";
     repo = "verus";
     tag = version;
-    hash = "sha256-Eggdfc/e/BGQuYt2gh4ghkvYWGPXjQslovoN/YQ4WHg=";
+    hash = "sha256-GN/SlM0QwjGdFC5ZM8uA04i7p9K/rJwhQ1+hx38K64I=";
   };
 
   rustToolchain = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";


### PR DESCRIPTION
- pkgs/tailscale: 1.103.80 -> 1.103.84
- pkgs/verus: release/rolling/0.2026.08.07.b678730 -> release/rolling/0.2026.08.07.5456f8c